### PR TITLE
[Feature] #24 주식 검색 연동 통합

### DIFF
--- a/src/api/stock.ts
+++ b/src/api/stock.ts
@@ -1,5 +1,17 @@
 import { apiClient } from "./client";
-import { StockPriceHistoryResponse, RecommendedSector } from "@/types/api";
+import { StockPriceHistoryResponse, RecommendedSector, StockSearchResponse, NewListingStock } from "@/types/api";
+
+/** 종목 수익률 응답 타입 */
+export interface StockReturnsResponse {
+  /** 종목 티커 */
+  ticker: string;
+  /** 조회 기간 */
+  period: string;
+  /** 종목 수익률 (%) */
+  stockReturnRate: number;
+  /** 벤치마크 수익률 (%) */
+  benchmarkReturnRate: number;
+}
 
 /**
  * 주식 종목 관련 API 호출 객체
@@ -10,20 +22,56 @@ export const stockApi = {
    * @returns 인기 검색어(티커/종목명) 리스트
    */
   getPopularSearch: async (): Promise<string[]> => {
-    const { data } = await apiClient.get("/v1/stocks/popular");
-    return data;
+    const data = await apiClient.get<string[]>("/v1/stocks/popular");
+    return data as unknown as string[];
   },
 
   /**
    * 검색어로 주식 종목을 검색합니다.
    * @param keyword 검색어 (종목명 또는 티커)
-   * @returns 검색 결과 리스트
+   * @param page 페이지 번호 (0부터 시작)
+   * @returns 검색 결과 리스트 (Slice 형태)
    */
-  search: async (keyword: string) => {
-    const { data } = await apiClient.get("/v1/stocks/search", {
+  search: async (keyword: string, page = 0): Promise<StockSearchResponse> => {
+    const data = await apiClient.get<StockSearchResponse>("/v1/stocks/search", {
+      params: { keyword, page, size: 20 },
+    });
+    return data as unknown as StockSearchResponse;
+  },
+
+  /**
+   * 신규 상장 종목 목록을 조회합니다.
+   * @returns 신규 상장 종목 리스트
+   */
+  getNewListings: async (): Promise<NewListingStock[]> => {
+    const data = await apiClient.get("/v1/stocks/new-listings");
+    return data as unknown as NewListingStock[];
+  },
+
+  /**
+   * 최근 검색어 목록을 조회합니다.
+   * @returns 최근 검색어 리스트
+   */
+  getSearchHistory: async (): Promise<string[]> => {
+    const data = await apiClient.get("/v1/stocks/search/history");
+    return data as unknown as string[];
+  },
+
+  /**
+   * 특정 검색어를 최근 검색어에서 삭제합니다.
+   * @param keyword 삭제할 검색어
+   */
+  deleteSearchHistory: async (keyword: string): Promise<void> => {
+    await apiClient.delete("/v1/stocks/search/history", {
       params: { keyword },
     });
-    return data;
+  },
+
+  /**
+   * 최근 검색어를 전체 삭제합니다.
+   */
+  clearSearchHistory: async (): Promise<void> => {
+    await apiClient.delete("/v1/stocks/search/history/all");
   },
 
   /**
@@ -33,10 +81,10 @@ export const stockApi = {
    * @returns 일별 주가 이력 및 벤치마크 데이터
    */
   getPriceHistory: async (ticker: string, period = "1Y"): Promise<StockPriceHistoryResponse> => {
-    const { data } = await apiClient.get(`/v1/stocks/${ticker}/prices/history`, {
+    const data = await apiClient.get(`/v1/stocks/${ticker}/prices/history`, {
       params: { period },
     });
-    return data;
+    return data as unknown as StockPriceHistoryResponse;
   },
 
   /**
@@ -45,18 +93,18 @@ export const stockApi = {
    * @param period 조회 기간 (기본값: 1Y)
    * @returns 해당 기간 내 종목 수익률 정보
    */
-  getReturns: async (ticker: string, period = "1Y") => {
-    const { data } = await apiClient.get(`/v1/stocks/${ticker}/returns`, {
+  getReturns: async (ticker: string, period = "1Y"): Promise<StockReturnsResponse> => {
+    const data = await apiClient.get(`/v1/stocks/${ticker}/returns`, {
       params: { period },
     });
-    return data;
+    return data as unknown as StockReturnsResponse;
   },
 
   /**
    * 섹터 등락률 랭킹 리스트를 조회합니다. (홈 화면 추천 섹터로 사용)
    */
   getRecommendedSectors: async (): Promise<RecommendedSector[]> => {
-    const { data } = await apiClient.get("/v1/sectors/ranking/fluctuation");
-    return data;
+    const data = await apiClient.get("/v1/sectors/ranking/fluctuation");
+    return data as unknown as RecommendedSector[];
   },
 };

--- a/src/hooks/use-stock.ts
+++ b/src/hooks/use-stock.ts
@@ -1,24 +1,61 @@
-import { useQuery } from "@tanstack/react-query";
-import { stockApi } from "@/api/stock";
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { stockApi, StockReturnsResponse } from "@/api/stock";
+import { StockSearchResponse, StockPriceHistoryResponse, RecommendedSector, NewListingStock } from "@/types/api";
 
 /**
  * 주식 종목 데이터 조회를 위한 커스텀 훅
  */
 export function useStock() {
+  const queryClient = useQueryClient();
+
   /** 인기 검색 종목 쿼리 */
-  const popular = useQuery({
+  const popular = useQuery<string[]>({
     queryKey: ["stocks", "popular"],
     queryFn: () => stockApi.getPopularSearch(),
+    staleTime: 1000 * 60 * 60, // 인기 검색어는 1시간 동안 유지
   });
 
   /**
-   * 종목 검색 쿼리
+   * 종목 검색 무한 쿼리 (Slice 구조 활용)
    * @param query 검색어 (2글자 이상 시 실행)
    */
-  const useSearch = (query: string) => useQuery({
+  const useSearch = (query: string) => useInfiniteQuery<StockSearchResponse>({
     queryKey: ["stocks", "search", query],
-    queryFn: () => stockApi.search(query),
-    enabled: query.length >= 2,
+    queryFn: ({ pageParam = 0 }) => stockApi.search(query, pageParam as number),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.number + 1 : undefined),
+    enabled: query.trim().length >= 2,
+    staleTime: 1000 * 60 * 5, // 검색 결과는 5분 동안 유지
+  });
+
+  /** 신규 상장 종목 조회 */
+  const newListings = useQuery<NewListingStock[]>({
+    queryKey: ["stocks", "new-listings"],
+    queryFn: () => stockApi.getNewListings(),
+    staleTime: 1000 * 60 * 60, // 1시간
+  });
+
+  /** 최근 검색어 조회 */
+  const searchHistory = useQuery<string[]>({
+    queryKey: ["stocks", "search", "history"],
+    queryFn: () => stockApi.getSearchHistory(),
+    staleTime: 0, // 항상 최신 데이터
+  });
+
+  /** 검색어 개별 삭제 */
+  const deleteHistory = useMutation({
+    mutationFn: (keyword: string) => stockApi.deleteSearchHistory(keyword),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["stocks", "search", "history"] });
+    },
+  });
+
+  /** 검색어 전체 삭제 */
+  const clearHistory = useMutation({
+    mutationFn: () => stockApi.clearSearchHistory(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["stocks", "search", "history"] });
+    },
   });
 
   /**
@@ -26,7 +63,7 @@ export function useStock() {
    * @param ticker 종목 티커
    * @param period 조회 기간
    */
-  const useHistory = (ticker: string, period: string) => useQuery({
+  const useHistory = (ticker: string, period: string) => useQuery<StockPriceHistoryResponse>({
     queryKey: ["stocks", ticker, "history", period],
     queryFn: () => stockApi.getPriceHistory(ticker, period),
     enabled: !!ticker,
@@ -37,7 +74,7 @@ export function useStock() {
    * @param ticker 종목 티커
    * @param period 조회 기간
    */
-  const useReturns = (ticker: string, period: string) => useQuery({
+  const useReturns = (ticker: string, period: string) => useQuery<StockReturnsResponse>({
     queryKey: ["stocks", ticker, "returns", period],
     queryFn: () => stockApi.getReturns(ticker, period),
     enabled: !!ticker,
@@ -46,7 +83,7 @@ export function useStock() {
   /** 
    * 추천 섹터
    */
-  const recommendedSectors = useQuery({
+  const recommendedSectors = useQuery<RecommendedSector[]>({
     queryKey: ["stocks", "sectors", "recommended"],
     queryFn: () => stockApi.getRecommendedSectors(),
   });
@@ -54,6 +91,10 @@ export function useStock() {
   return {
     popular,
     useSearch,
+    newListings,
+    searchHistory,
+    deleteHistory,
+    clearHistory,
     useHistory,
     useReturns,
     recommendedSectors,


### PR DESCRIPTION
## 개요\n\n주식 검색 API 타입 정의, useStock 훅 리팩토링, 검색 UI 에러 처리, E2E 테스트를 포함하는 통합 PR입니다.\n\n## 포함된 하위 작업\n\n| 이슈 | 작업 | 상태 |\n|------|------|------|\n| #25 | 주식 검색 API 및 인기 검색어 데이터 타입 정의 | ✅ |\n| #26 | API 호출 함수 및 useStock 훅 타입 리팩토링 | ✅ |\n| #27 | 검색 화면 UI 연동 최적화 및 에러 처리 구현 | ✅ |\n| #28 | 주식 검색 기능 통합 테스트(E2E) 작성 | ✅ |\n\n## 주요 변경 사항\n\n- `getNewListings`, `getSearchHistory`, `deleteSearchHistory`, `clearSearchHistory` API 함수 추가\n- `StockReturnsResponse` 타입 정의 및 `getReturns` 반환 타입 명시\n- useStock 훅: `newListings`, `searchHistory` 쿼리 및 `deleteHistory`, `clearHistory` 뮤테이션 추가\n- 모든 `useQuery` 제네릭 타입 명시\n\nCloses #24\nCloses #25\nCloses #26\nCloses #27\nCloses #28