### PR TITLE
fix: 섹터 랭킹 API 중복 호출 제거 #49

### DIFF
--- a/src/api/stock.ts
+++ b/src/api/stock.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./client";
-import { StockPriceHistoryResponse, RecommendedSector, StockSearchResponse, NewListingStock } from "@/types/api";
+import { StockPriceHistoryResponse, StockSearchResponse, NewListingStock } from "@/types/api";
 
 /** 종목 수익률 응답 타입 */
 export interface StockReturnsResponse {
@@ -98,13 +98,5 @@ export const stockApi = {
       params: { period },
     });
     return data as unknown as StockReturnsResponse;
-  },
-
-  /**
-   * 섹터 등락률 랭킹 리스트를 조회합니다. (홈 화면 추천 섹터로 사용)
-   */
-  getRecommendedSectors: async (): Promise<RecommendedSector[]> => {
-    const data = await apiClient.get("/v1/sectors/ranking/fluctuation");
-    return data as unknown as RecommendedSector[];
   },
 };

--- a/src/hooks/use-stock.ts
+++ b/src/hooks/use-stock.ts
@@ -1,6 +1,6 @@
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { stockApi, StockReturnsResponse } from "@/api/stock";
-import { StockSearchResponse, StockPriceHistoryResponse, RecommendedSector, NewListingStock } from "@/types/api";
+import { StockSearchResponse, StockPriceHistoryResponse, NewListingStock } from "@/types/api";
 
 /**
  * 주식 종목 데이터 조회를 위한 커스텀 훅
@@ -80,14 +80,6 @@ export function useStock() {
     enabled: !!ticker,
   });
 
-  /** 
-   * 추천 섹터
-   */
-  const recommendedSectors = useQuery<RecommendedSector[]>({
-    queryKey: ["stocks", "sectors", "recommended"],
-    queryFn: () => stockApi.getRecommendedSectors(),
-  });
-
   return {
     popular,
     useSearch,
@@ -97,6 +89,5 @@ export function useStock() {
     clearHistory,
     useHistory,
     useReturns,
-    recommendedSectors,
   };
 }


### PR DESCRIPTION
## Summary

- `stockApi.getRecommendedSectors()` 제거 — `sectorApi.getFluctuationRanking()`과 동일한 엔드포인트(`GET /api/v1/sectors/ranking/fluctuation`)를 중복 구현한 함수
- `useStock()` 내 `recommendedSectors` 쿼리 제거 — `Home.tsx`는 `useSector()`를 통해 섹터 데이터를 조회하므로 불필요한 쿼리가 자동 실행되고 있었음
- 관련 `RecommendedSector` import 정리

## Test plan

- [ ] 홈 화면 진입 시 `/api/v1/sectors/ranking/fluctuation` 요청이 1회만 발생하는지 확인 (Network 탭)
- [ ] 섹터 카드가 정상적으로 렌더링되는지 확인

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)