### PR TITLE
fix: getHoldings() 반환 타입을 PortfolioResponse로 수정 #54

### DIFF
--- a/src/api/portfolio.ts
+++ b/src/api/portfolio.ts
@@ -5,7 +5,6 @@ import {
   PortfolioRebalancingResponse,
   BacktestRequest,
   BacktestResponse,
-  PortfolioItemResponse,
   PortfolioResponse,
   CorrelationMatrix,
   CreatePortfolioRequest,
@@ -37,9 +36,9 @@ export const portfolioApi = {
    * @param portfolioId 포트폴리오 ID
    * @returns 보유 종목 리스트
    */
-  getHoldings: async (portfolioId: string): Promise<PortfolioItemResponse[]> => {
+  getHoldings: async (portfolioId: string): Promise<PortfolioResponse> => {
     const { data } = await apiClient.get<PortfolioResponse>(`/v1/portfolios/${portfolioId}`);
-    return data.items;
+    return data;
   },
 
   /**

--- a/src/app/components/screens/BacktestSetup.tsx
+++ b/src/app/components/screens/BacktestSetup.tsx
@@ -56,9 +56,9 @@ export function BacktestSetup() {
 
   // 보유 종목을 초기 포트폴리오로 설정
   useEffect(() => {
-    if (holdings && holdings.length > 0) {
+    if (holdings && holdings.items.length > 0) {
       setPortfolio(
-        holdings.map((item) => ({
+        holdings.items.map((item) => ({
           symbol: item.symbol,
           name: item.symbol, // PortfolioItemResponse에 name 미제공 — symbol로 대체
           weight: item.targetWeight,

--- a/src/app/components/screens/More.tsx
+++ b/src/app/components/screens/More.tsx
@@ -68,7 +68,7 @@ export function More() {
                   : "2024.01"
               }
             />
-            <MetricItem label="보유 종목" value={`${holdings?.length ?? "-"}개`} />
+            <MetricItem label="보유 종목" value={`${holdings?.items?.length ?? "-"}개`} />
             <MetricItem
               label="총 수익률"
               value={

--- a/src/app/components/screens/Portfolio.tsx
+++ b/src/app/components/screens/Portfolio.tsx
@@ -116,8 +116,8 @@ export function Portfolio() {
            <button className="text-primary text-sm font-semibold">편집</button>
         </div>
 
-        {holdings && holdings.length > 0 ? (
-          <HoldingsList holdings={holdings} />
+        {holdings && holdings.items.length > 0 ? (
+          <HoldingsList holdings={holdings.items} />
         ) : (
           <div className="bg-card rounded-3xl p-8 text-center shadow-sm border border-border">
             <div className="text-muted-foreground mb-2">아직 보유한 주식이 없어요.</div>


### PR DESCRIPTION
## 요약
- `portfolioApi.getHoldings()` 반환 타입을 `PortfolioItemResponse[]` → `PortfolioResponse`로 변경
- 내부에서 `.items`만 추출하던 로직 제거, 전체 객체 반환으로 수정
- `holdings`를 참조하는 컴포넌트 3곳에서 `.items` 접근으로 수정

## 변경 파일
- `src/api/portfolio.ts` — 반환 타입 및 return 값 수정, 미사용 import 제거
- `src/app/components/screens/More.tsx` — `holdings?.length` → `holdings?.items?.length`
- `src/app/components/screens/Portfolio.tsx` — `holdings.length` / `holdings={holdings}` → `.items` 접근
- `src/app/components/screens/BacktestSetup.tsx` — `holdings.length` / `holdings.map` → `.items` 접근

Closes #54