### PR TITLE
refactor: CreatePortfolioItemRequest.assetType union 타입 구체화 #55

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -472,7 +472,7 @@ export interface CreatePortfolioItemRequest {
   quantity: number;
   purchasePrice: number;
   currency: string;
-  assetType: string;
+  assetType: "STOCK" | "CASH";
   targetWeight: number;
 }
 


### PR DESCRIPTION
## 요약
- `CreatePortfolioItemRequest.assetType`을 `string` → `"STOCK" | "CASH"` union 타입으로 변경
- 백엔드 enum 외의 값이 전송되는 것을 컴파일 타임에 차단

## 변경 파일
- `src/types/api.ts` — `assetType: string` → `assetType: "STOCK" | "CASH"`

Closes #55