### PR TITLE
refactor: ApiResponse<T> 성공/에러 envelope 타입 분리 #56

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7,15 +7,20 @@ export interface FieldError {
   reason: string;
 }
 
-export interface ApiResponse<T> {
-  success: boolean;       // @JsonProperty("success") 반영
-  status: number;         // HTTP 상태 코드
-  code: string;           // 서비스 내부 코드
-  message: string;        // 응답 메시지
-  data: T;                // 실제 비즈니스 데이터
-  timestamp: string;      // 응답 생성 시간 (ISO-8601)
-  traceId: string | null; // 에러 추적용 ID
-  errors: FieldError[];   // 상세 필드 에러 목록
+/** 성공 응답 래퍼 — 백엔드 실제 구조: { data, timestamp } */
+export interface SuccessEnvelope<T> {
+  data: T;
+  timestamp: string;
+}
+
+/** 에러 응답 래퍼 */
+export interface ErrorEnvelope {
+  status: number;
+  code: string;
+  message: string;
+  timestamp: string;
+  traceId: string | null;
+  errors: FieldError[];
 }
 
 /**


### PR DESCRIPTION
## 요약
- `ApiResponse<T>` (성공/에러 필드 혼합) 삭제
- `SuccessEnvelope<T> { data, timestamp }` — 백엔드 실제 성공 응답 구조 반영
- `ErrorEnvelope { status, code, message, timestamp, traceId, errors }` — 에러 응답 구조 분리

## 배경
axios 인터셉터가 `response.data.data`로 언래핑하므로 런타임 오류는 없었으나, `ApiResponse<T>`가 실제 백엔드 구조와 달라 혼란을 유발했음.

## 변경 파일
- `src/types/api.ts` — `ApiResponse<T>` → `SuccessEnvelope<T>` + `ErrorEnvelope`

Closes #56