### PR TITLE
feat(home): 기상도 위젯 7단계 UI 적용 및 상단 인사말 통합

### DIFF
--- a/src/api/marketWeatherApi.ts
+++ b/src/api/marketWeatherApi.ts
@@ -1,0 +1,33 @@
+import { apiClient } from "./client";
+
+export interface MarketWeatherResponse {
+  baseDate: string;
+  marketType: string;
+  weatherScore: number;
+  weatherState: string;
+  weatherEmoji: string;
+  aiSummary: string;
+  topSectors: SectorWeatherDto[];
+  bottomSectors: SectorWeatherDto[];
+}
+
+export interface SectorWeatherDto {
+  sectorCode: string;
+  sectorName: string;
+  score: number;
+  state: string;
+  emoji: string;
+  aiTitle: string;
+  aiInsight: string;
+}
+
+export const marketWeatherKeys = {
+  all: ["market-weather"] as const,
+  latest: () => [...marketWeatherKeys.all, "latest"] as const,
+};
+
+export const marketWeatherApi = {
+  getLatest: async (): Promise<MarketWeatherResponse> => {
+    return await apiClient.get("/v1/market-weather/latest");
+  },
+};

--- a/src/app/components/home/MarketIndexCard.tsx
+++ b/src/app/components/home/MarketIndexCard.tsx
@@ -1,8 +1,8 @@
 import { motion } from "motion/react";
 import { Skeleton } from "@/app/components/ui";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { useMarketIndex } from "@/hooks/use-market-index";
 import { MarketIndexResult } from "@/types/api";
-import { getTrendClassName } from "@/utils/trend";
 import { HomeBadge } from "./HomeListItem";
 import { getHomeCardTone } from "./home-card-tone";
 
@@ -43,8 +43,7 @@ export function MarketIndexSection() {
 }
 
 function MarketIndexCard({ index }: { index: MarketIndexResult }) {
-  const isUp = index.fluctuationRate >= 0;
-  const tone = getHomeCardTone(isUp ? "up" : "down");
+  const tone = getHomeCardTone(index.fluctuationRate >= 0 ? "up" : "down");
   
   // 시장별 아이콘 결정 로직 (한글/영어 대응)
   const getIndexIcon = (name: string) => {
@@ -96,11 +95,14 @@ function MarketIndexCard({ index }: { index: MarketIndexResult }) {
         </p>
 
         <div className="flex items-center gap-2">
-          <p className={`text-sm font-bold tabular-nums ${getTrendClassName(index.fluctuationRate, { neutral: "text-up" })}`}>
-            {isUp ? "▲ " : "▼ "}{Math.abs(index.fluctuationRate).toFixed(2)}%
-          </p>
+          <SignedValueLabel
+            value={index.fluctuationRate}
+            format="percent"
+            className="text-sm font-bold"
+            ariaLabelPrefix={`${index.name} 등락률`}
+          />
           <HomeBadge opacity={20} className={`text-[10px] py-0 px-1.5 h-4 ${tone.badgeClassName}`}>
-            {isUp ? "상승" : "하락"}
+            {index.fluctuationRate > 0 ? "상승" : index.fluctuationRate < 0 ? "하락" : "보합"}
           </HomeBadge>
         </div>
       </div>

--- a/src/app/components/home/MarketWeatherWidget.tsx
+++ b/src/app/components/home/MarketWeatherWidget.tsx
@@ -1,0 +1,118 @@
+import { Cloud, Sun, CloudRain, Zap, CloudSun, CloudFog, SunMedium } from "lucide-react";
+import { motion } from "motion/react";
+import { useMarketWeather } from "@/hooks/use-market-weather";
+import { Skeleton, Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/app/components/ui";
+import { useAuthStore } from "@/store/auth";
+
+export function MarketWeatherWidget() {
+  const { data: weather, isLoading, isError } = useMarketWeather();
+  const nickname = useAuthStore((state) => state.nickname);
+
+  if (isLoading) {
+    return <Skeleton className="h-[120px] w-full rounded-2xl" />;
+  }
+
+  if (isError || !weather) {
+    return null;
+  }
+
+  const getWeatherAppearance = (state: string) => {
+    switch (state) {
+      case "CLEAR": 
+        return { icon: <SunMedium className="h-8 w-8 text-orange-500" />, label: "매우 맑음", color: "text-orange-500" };
+      case "SUNNY": 
+        return { icon: <Sun className="h-8 w-8 text-yellow-500" />, label: "맑음", color: "text-yellow-500" };
+      case "PARTLY_CLOUDY": 
+        return { icon: <CloudSun className="h-8 w-8 text-blue-400" />, label: "구름 조금", color: "text-blue-400" };
+      case "CLOUDY": 
+        return { icon: <Cloud className="h-8 w-8 text-gray-400" />, label: "흐림", color: "text-gray-400" };
+      case "FOGGY": 
+        return { icon: <CloudFog className="h-8 w-8 text-amber-600" />, label: "안개", color: "text-amber-600" };
+      case "RAINY": 
+        return { icon: <CloudRain className="h-8 w-8 text-blue-600" />, label: "비", color: "text-blue-600" };
+      case "STORMY": 
+        return { icon: <Zap className="h-8 w-8 text-purple-600" />, label: "천둥번개", color: "text-purple-600" };
+      default: 
+        return { icon: <Cloud className="h-8 w-8 text-gray-400" />, label: state, color: "text-primary" };
+    }
+  };
+
+  const appearance = getWeatherAppearance(weather.weatherState);
+
+  return (
+    <motion.div 
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="mx-4 overflow-hidden rounded-2xl border border-border/50 bg-card/30 p-5 backdrop-blur-sm md:mx-0"
+    >
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {weather.marketType} Market Insight
+            </span>
+            <div className="h-1 w-1 rounded-full bg-border" />
+            <span className="text-xs text-muted-foreground">{weather.baseDate}</span>
+          </div>
+          <h3 className="text-xl md:text-2xl font-bold tracking-tight mt-1 leading-snug">
+            {nickname ?? "투자자"}님,<br />
+            오늘의 증시는 <span className={appearance.color}>'{appearance.label}'</span>이에요 {appearance.icon.props.children}
+          </h3>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-bold text-primary cursor-help">
+                  Score {weather.weatherScore}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent align="end">
+                <div className="space-y-1 text-left">
+                  <p className="font-semibold text-sm">기상 점수 산출 기준</p>
+                  <ul className="text-[11px] text-muted-foreground list-disc pl-4">
+                    <li>이격도 점수 (40%): MA20 기준 상하편차</li>
+                    <li>RSI 상대강도 (30%): 최근 14일 상승압력</li>
+                    <li>ADR 등락비율 (30%): 상승/하락 종목 비율</li>
+                  </ul>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <div className="mt-1">{appearance.icon}</div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-xl bg-muted/50 p-4">
+        <p className="text-sm leading-relaxed text-foreground/90">
+          {weather.aiSummary}
+        </p>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <span className="text-[10px] font-bold uppercase text-muted-foreground/70">Top Sectors</span>
+          <div className="flex flex-wrap gap-1.5">
+            {weather.topSectors.map((s) => (
+              <div key={s.sectorCode} className="flex items-center gap-1 rounded-md bg-green-500/10 px-2 py-1 text-[11px] font-medium text-green-600 dark:text-green-400">
+                <span>{s.emoji}</span>
+                <span>{s.sectorName && s.sectorName !== s.sectorCode ? s.sectorName : s.sectorCode}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <span className="text-[10px] font-bold uppercase text-muted-foreground/70">Watch Out</span>
+          <div className="flex flex-wrap gap-1.5">
+            {weather.bottomSectors.map((s) => (
+              <div key={s.sectorCode} className="flex items-center gap-1 rounded-md bg-red-500/10 px-2 py-1 text-[11px] font-medium text-red-600 dark:text-red-400">
+                <span>{s.emoji}</span>
+                <span>{s.sectorName && s.sectorName !== s.sectorCode ? s.sectorName : s.sectorCode}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/app/components/home/SectorBottomSheet.tsx
+++ b/src/app/components/home/SectorBottomSheet.tsx
@@ -4,18 +4,18 @@ import { motion } from "motion/react";
 import { 
   ComposedChart, 
   Area, 
-  Line, 
   XAxis, 
   YAxis, 
   Tooltip, 
   ResponsiveContainer, 
-  Cell,
   ReferenceLine
 } from "recharts";
-import { Sparkles, ArrowRight, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { Sparkles, ArrowRight } from "lucide-react";
 import { Sheet, SheetContent, Skeleton } from "@/app/components/ui";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { LeadingStock, TechnicalIndicators, SectorComparisonResponse } from "@/types/api";
-import { formatCurrency, formatPercent } from "@/utils/format";
+import { formatCurrency, formatSignedCurrency } from "@/utils/format";
+import { getTrendClassName } from "@/utils/trend";
 import { useSectorDetail, useSector } from "@/hooks/use-sector";
 
 const CHART_COLORS = {
@@ -123,9 +123,12 @@ function SheetBody({
               {(sector.currentPrice ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2 })}
             </p>
             <div className="flex items-center gap-2">
-              <p className={`text-base font-bold tabular-nums ${isUp ? "text-up" : "text-down"}`}>
-                {formatPercent(sector.fluctuationRate)}
-              </p>
+              <SignedValueLabel
+                value={sector.fluctuationRate}
+                format="percent"
+                className="text-base font-bold"
+                ariaLabelPrefix={`${sector.sectorName} 등락률`}
+              />
               <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border ${
                 isUp ? "border-up/30 bg-up/10 text-up" : "border-down/30 bg-down/10 text-down"
               }`}>
@@ -249,7 +252,6 @@ function CustomTooltip({ active, payload }: any) {
   if (!active || !payload?.length) return null;
   const data = payload[0].payload;
   const rate = data.sectorRate ?? 0;
-  const isUp = rate >= 0;
 
   return (
     <div className="bg-card/90 backdrop-blur-md border border-border p-3 rounded-2xl shadow-xl min-w-[120px]">
@@ -260,31 +262,33 @@ function CustomTooltip({ active, payload }: any) {
       </div>
       <div className="flex justify-between items-center gap-4">
         <span className="text-[11px] font-bold text-muted-foreground">수익률</span>
-        <span className={`text-[12px] font-extrabold font-mono ${isUp ? "text-up" : "text-down"}`}>
-          {isUp ? "+" : ""}{rate.toFixed(2)}%
-        </span>
+        <SignedValueLabel value={rate} format="percent" className="text-[12px] font-extrabold font-mono" />
       </div>
     </div>
   );
 }
 
 function SummaryItem({ label, value, color, isPercent }: { label: string; value: string | number; color: "up" | "down" | "neutral"; isPercent?: boolean }) {
+  const numericValue = typeof value === "number" ? value : Number(value);
+
   return (
     <div className="bg-secondary/20 rounded-2xl p-3 text-center border border-border/50">
       <p className="text-[10px] font-bold text-muted-foreground mb-1">{label}</p>
-      <p className={`text-[14px] font-black font-mono ${
-        color === "up" ? "text-up" : color === "down" ? "text-down" : "text-foreground"
-      }`}>
-        {isPercent && Number(value) > 0 ? "+" : ""}{value}{isPercent ? "%" : ""}
-      </p>
+      {isPercent && Number.isFinite(numericValue) ? (
+        <SignedValueLabel value={numericValue} format="percent" className="text-[14px] font-black font-mono" />
+      ) : (
+        <p className={`text-[14px] font-black font-mono ${
+          color === "up" ? "text-up" : color === "down" ? "text-down" : "text-foreground"
+        }`}>
+          {value}
+        </p>
+      )}
     </div>
   );
 }
 
 function LeadingStockItem({ stock }: { stock: LeadingStock }) {
   const navigate = useNavigate();
-  const isUp = stock.fluctuationRate > 0;
-  const isDown = stock.fluctuationRate < 0;
 
   return (
     <motion.div 
@@ -303,11 +307,9 @@ function LeadingStockItem({ stock }: { stock: LeadingStock }) {
       </div>
       <div className="text-right">
         <p className="text-foreground font-bold text-[15px] font-mono">{formatCurrency(stock.currentPrice)}원</p>
-        <div className={`flex items-center justify-end gap-1 text-[12px] font-bold font-mono ${
-          isUp ? "text-up" : isDown ? "text-down" : "text-muted-foreground"
-        }`}>
-          {isUp ? <TrendingUp className="h-3 w-3" /> : isDown ? <TrendingDown className="h-3 w-3" /> : <Minus className="h-3 w-3" />}
-          {Math.abs(stock.changePrice).toLocaleString()} ({Math.abs(stock.fluctuationRate).toFixed(2)}%)
+        <div className={`flex items-center justify-end gap-1 text-[12px] font-bold font-mono ${getTrendClassName(stock.fluctuationRate)}`}>
+          <span>{formatSignedCurrency(stock.changePrice)}</span>
+          <SignedValueLabel value={stock.fluctuationRate} format="percent" />
         </div>
       </div>
     </motion.div>
@@ -345,4 +347,3 @@ function getStats(data?: any[]) {
     isUp: change >= 0
   };
 }
-

--- a/src/app/components/home/SectorBottomSheet.tsx
+++ b/src/app/components/home/SectorBottomSheet.tsx
@@ -35,6 +35,10 @@ export interface SectorData {
   leadingStocks?: LeadingStock[];
   technicalIndicators?: Partial<TechnicalIndicators> | null;
   detailLoading?: boolean;
+  weatherScore?: number;
+  weatherState?: string;
+  weatherEmoji?: string;
+  aiInsight?: string;
 }
 
 interface SectorBottomSheetProps {
@@ -139,18 +143,31 @@ function SheetBody({
         </div>
 
         {/* 2. AI 인사이트 (컴팩트 카드) */}
-        {(sector.diagnosisMessage || sector.detailLoading) && (
+        {(sector.diagnosisMessage || sector.aiInsight || sector.detailLoading) && (
           <div className="bg-card rounded-2xl p-4 border border-border/70 shadow-sm">
-            <h3 className="text-[11px] font-black text-primary uppercase tracking-wider mb-2 flex items-center gap-1.5">
-              <Sparkles className="h-3 w-3" /> AI Insight
-            </h3>
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-[11px] font-black text-primary uppercase tracking-wider flex items-center gap-1.5">
+                <Sparkles className="h-3 w-3" /> AI Weather Insight
+              </h3>
+              {sector.weatherScore !== undefined && (
+                <div className="flex items-center gap-1 bg-primary/5 px-2 py-0.5 rounded-full border border-primary/10">
+                  <span className="text-[10px] font-bold text-primary">{sector.weatherEmoji} {sector.weatherScore}점</span>
+                </div>
+              )}
+            </div>
             {sector.detailLoading ? (
               <div className="space-y-2">
                 <Skeleton className="h-3 w-full" />
                 <Skeleton className="h-3 w-4/5" />
               </div>
             ) : (
-              <p className="text-[13px] text-foreground font-medium leading-relaxed">{sector.diagnosisMessage}</p>
+              <div className="space-y-2">
+                {sector.aiInsight ? (
+                  <p className="text-[13px] text-foreground font-medium leading-relaxed">{sector.aiInsight}</p>
+                ) : (
+                  <p className="text-[13px] text-foreground font-medium leading-relaxed">{sector.diagnosisMessage}</p>
+                )}
+              </div>
             )}
           </div>
         )}

--- a/src/app/components/home/SectorRankingSection.tsx
+++ b/src/app/components/home/SectorRankingSection.tsx
@@ -1,4 +1,5 @@
 import { motion } from "motion/react";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { useSector } from "@/hooks/use-sector";
 import { HomeCard, HomeCardSkeleton } from "./HomeCard";
 import { HomeBadge } from "./HomeListItem";
@@ -80,9 +81,11 @@ function RankingCard({
         )
       }
       displayValue={
-        <span className={isUp ? "text-up" : "text-down"}>
-          {isUp ? "▲ " : "▼ "}{Math.abs(sector.fluctuationRate).toFixed(2)}%
-        </span>
+        <SignedValueLabel
+          value={sector.fluctuationRate}
+          format="percent"
+          ariaLabelPrefix={`${sector.sectorName} 등락률`}
+        />
       }
     />
   );

--- a/src/app/components/home/StockSupplyRankingSection.tsx
+++ b/src/app/components/home/StockSupplyRankingSection.tsx
@@ -6,8 +6,8 @@ import { HomeBadge } from "./HomeListItem";
 import { HomeCard, HomeCardSkeleton } from "./HomeCard";
 import { useStockSupplyRanking } from "@/hooks/use-stock";
 import { StockSupplyRankingItem, TradeDirection } from "@/types/api";
-import { formatPercent } from "@/utils/format";
 import { getTrendClassName } from "@/utils/trend";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { getHomeCardTone } from "./home-card-tone";
 
 const containerVariants = {
@@ -42,7 +42,7 @@ function formatAmount(value: number) {
 }
 
 function formatEffectiveDate(date: string) {
-  return date.replaceAll("-", ".");
+  return date.replace(/-/g, ".");
 }
 
 function formatCurrentPrice(value: number) {
@@ -87,6 +87,7 @@ function RankingCard({
   onItemClick: (ticker: string) => void;
 }) {
   const tone = getHomeCardTone(direction === "BUY" ? "up" : "down");
+  const signedNetAmount = direction === "BUY" ? Math.abs(item.netBuyingAmount) : -Math.abs(item.netBuyingAmount);
 
   return (
     <HomeCard
@@ -104,17 +105,23 @@ function RankingCard({
       displayValue={
         <div className="flex items-center gap-2 tabular-nums">
           <span className="text-foreground">{formatCurrentPrice(item.currentPrice)}</span>
-          <span className={getTrendClassName(item.fluctuationRate)}>
-            {formatPercent(item.fluctuationRate).replace(" ", "")}
-          </span>
+          <SignedValueLabel
+            value={item.fluctuationRate}
+            format="percent"
+            className="font-semibold"
+            ariaLabelPrefix={`${item.stockName} 등락률`}
+          />
         </div>
       }
       description={
         <div className="flex items-center gap-1 tabular-nums text-xs">
           <span className="text-muted-foreground">{getNetAmountLabel(direction)}</span>
-          <span className={getTrendClassName(item.netBuyingAmount)}>
-            {direction === "BUY" ? "▲ " : "▼ "}
-            {formatAmount(item.netBuyingAmount)}
+          <span
+            className={getTrendClassName(signedNetAmount)}
+            aria-label={`${item.stockName} ${getNetAmountLabel(direction)} ${signedNetAmount > 0 ? "상승" : signedNetAmount < 0 ? "하락" : "보합"}`}
+          >
+            {signedNetAmount > 0 ? "▲ " : signedNetAmount < 0 ? "▼ " : ""}
+            {formatAmount(signedNetAmount)}
           </span>
         </div>
       }

--- a/src/app/components/home/SupplyDemandSection.tsx
+++ b/src/app/components/home/SupplyDemandSection.tsx
@@ -1,5 +1,6 @@
 import { motion } from "motion/react";
 import { Progress } from "@/app/components/ui";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { useSupply } from "@/hooks/use-supply";
 import { SectorSupplyItem } from "@/types/api";
 import { HomeCard, HomeCardSkeleton } from "./HomeCard";
@@ -94,7 +95,6 @@ function SupplyCard({
   const progressValue = maxAmount > 0 ? (dominantAmt / maxAmount) * 100 : 0;
   const secondaryWidth = maxAmount > 0 ? (secondaryAmt / maxAmount) * 100 : 0;
   
-  const formattedAmt = `${(dominantAmt / 1e8).toFixed(0)}억`;
   const badgeOpacity = consecutiveDays >= 10 ? 30 : consecutiveDays >= 5 ? 20 : 10;
 
   return (
@@ -117,7 +117,16 @@ function SupplyCard({
         </div>
       }
       displayValue={
-        <span className="text-up">+{formattedAmt} 유입</span>
+        <span>
+          <SignedValueLabel
+            value={dominantAmt / 1e8}
+            format="number"
+            fractionDigits={0}
+            showArrow
+            ariaLabelPrefix={`${sector.sectorName} 수급 유입액`}
+          />억{" "}
+          유입
+        </span>
       }
       description={
         <div className="flex flex-col gap-1 w-full mt-1">

--- a/src/app/components/home/__tests__/StockSupplyRankingSection.test.tsx
+++ b/src/app/components/home/__tests__/StockSupplyRankingSection.test.tsx
@@ -201,8 +201,6 @@ describe("StockSupplyRankingSection", () => {
       </MemoryRouter>
     );
 
-    // The implementation formats it as: {direction === "BUY" ? "▲ " : "▼ "}{formatAmount(item.netBuyingAmount)}
-    // And formatAmount(NaN) returns "-"
-    expect(screen.getByText(/▲ -/)).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 });

--- a/src/app/components/home/market-weather-presentation.ts
+++ b/src/app/components/home/market-weather-presentation.ts
@@ -7,18 +7,18 @@ export interface MarketWeatherPresentation {
   toneClassName: string;
 }
 
-const WEATHER_APPEARANCE: Record<MarketWeatherLevel, { emoji: string; toneClassName: string }> = {
-  CLEAR: { emoji: "☀️", toneClassName: "text-up" },
-  SUNNY: { emoji: "🌤️", toneClassName: "text-up" },
-  PARTLY_CLOUDY: { emoji: "🌥️", toneClassName: "text-emerald-600" },
-  CLOUDY: { emoji: "⛅", toneClassName: "text-muted-foreground" },
-  FOGGY: { emoji: "🌫️", toneClassName: "text-amber-600" },
-  RAINY: { emoji: "🌧️", toneClassName: "text-down" },
-  STORMY: { emoji: "⛈️", toneClassName: "text-down" },
+const WEATHER_APPEARANCE: Record<string, { emoji: string; toneClassName: string; label: string }> = {
+  CLEAR: { emoji: "☀️", toneClassName: "text-orange-500", label: "매우 맑음" },
+  SUNNY: { emoji: "🌤️", toneClassName: "text-yellow-500", label: "맑음" },
+  PARTLY_CLOUDY: { emoji: "🌥️", toneClassName: "text-blue-400", label: "구름 조금" },
+  CLOUDY: { emoji: "⛅", toneClassName: "text-muted-foreground", label: "흐림" },
+  FOGGY: { emoji: "🌫️", toneClassName: "text-amber-600", label: "안개" },
+  RAINY: { emoji: "🌧️", toneClassName: "text-blue-600", label: "비" },
+  STORMY: { emoji: "⛈️", toneClassName: "text-purple-600", label: "천둥번개" },
 };
 
 export function getMarketWeatherPresentation(
-  weather: MarketWeatherResult | null | undefined,
+  weather: any, // API 응답 타입에 맞춰 유연하게 처리
   isLoading: boolean,
   isError: boolean,
 ): MarketWeatherPresentation {
@@ -40,10 +40,12 @@ export function getMarketWeatherPresentation(
     };
   }
 
-  const appearance = WEATHER_APPEARANCE[weather.weatherLevel];
+  const state = weather.weatherState || "CLOUDY";
+  const appearance = WEATHER_APPEARANCE[state] || WEATHER_APPEARANCE.CLOUDY;
+
   return {
-    text: weather.weatherMessage,
-    description: weather.weatherDescription,
+    text: `오늘의 증시는 ${appearance.label}이에요`,
+    description: weather.aiSummary || "시장의 주요 지표를 기반으로 분석한 결과입니다.",
     emoji: appearance.emoji,
     toneClassName: appearance.toneClassName,
   };

--- a/src/app/components/portfolio/PortfolioHoldingsSheet.tsx
+++ b/src/app/components/portfolio/PortfolioHoldingsSheet.tsx
@@ -4,7 +4,8 @@ import {
 } from "@/app/components/ui/drawer";
 import { DrawerSheetHeader } from "@/app/components/shared/DrawerSheetHeader";
 import { usePortfolioDetails } from "@/hooks/use-portfolio";
-import { formatCurrency, formatPercent } from "@/utils/format";
+import { formatCurrency } from "@/utils/format";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 
 interface PortfolioHoldingsSheetProps {
   isOpen: boolean;
@@ -46,13 +47,12 @@ export function PortfolioHoldingsSheet({ isOpen, onClose }: PortfolioHoldingsShe
                   <span className="text-[10px] text-muted-foreground">
                     평단 ₩{formatCurrency(item.purchasePrice)}
                   </span>
-                  <span
-                    className={`text-[11px] font-bold tabular-nums ${
-                      (item.returnRate ?? 0) >= 0 ? "text-up" : "text-down"
-                    }`}
-                  >
-                    {formatPercent(item.returnRate ?? 0)}
-                  </span>
+                  <SignedValueLabel
+                    value={item.returnRate ?? 0}
+                    format="percent"
+                    className="text-[11px] font-bold"
+                    ariaLabelPrefix={`${item.name || item.symbol} 수익률`}
+                  />
                 </div>
               </div>
             </div>

--- a/src/app/components/portfolio/tabs/CompositionTab.tsx
+++ b/src/app/components/portfolio/tabs/CompositionTab.tsx
@@ -1,7 +1,8 @@
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { Skeleton } from "@/app/components/ui";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { usePortfolioDetails } from "@/hooks/use-portfolio";
-import { formatCurrency, formatPercent } from "@/utils/format";
+import { formatCurrency } from "@/utils/format";
 
 const CHART_COLORS = ["var(--primary)", "#1A56DB", "#F59E0B", "#EF4444", "#8B5CF6", "#6B7280"];
 
@@ -91,11 +92,15 @@ export function CompositionTab() {
               </p>
               <div className="text-right">
                 <p className="text-foreground tabular-nums">₩{formatCurrency(item.currentPrice ?? item.purchasePrice)}</p>
-                <p className={`text-xs tabular-nums ${(item.currentValue ?? 0) - item.purchaseAmount >= 0 ? "text-up" : "text-down"}`}>
-                  {`${(item.currentValue ?? 0) - item.purchaseAmount >= 0 ? "+" : "-"}₩${formatCurrency(Math.abs((item.currentValue ?? 0) - item.purchaseAmount))}`}
+                <p className="text-xs">
+                  <SignedValueLabel
+                    value={(item.currentValue ?? 0) - item.purchaseAmount}
+                    format="currency"
+                    ariaLabelPrefix={`${item.name || item.symbol} 평가손익`}
+                  />
                 </p>
-                <p className={`text-xs tabular-nums ${(item.returnRate ?? 0) >= 0 ? "text-up" : "text-down"}`}>
-                  {formatPercent(item.returnRate ?? 0)}
+                <p className="text-xs">
+                  <SignedValueLabel value={item.returnRate ?? 0} format="percent" ariaLabelPrefix={`${item.name || item.symbol} 수익률`} />
                 </p>
               </div>
             </div>

--- a/src/app/components/portfolio/tabs/SimulationTab.tsx
+++ b/src/app/components/portfolio/tabs/SimulationTab.tsx
@@ -8,10 +8,10 @@ import {
   YAxis,
 } from "recharts";
 import { Skeleton } from "@/app/components/ui";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { usePortfolioCorrelation, usePortfolioDetails } from "@/hooks/use-portfolio";
 import { usePortfolioSimulation } from "@/hooks/use-backtest";
 import { CorrelationMatrix } from "@/types/api";
-import { formatPercent } from "@/utils/format";
 
 const PERIOD_OPTIONS = ["1M", "3M", "6M", "1Y"] as const;
 type Period = (typeof PERIOD_OPTIONS)[number];
@@ -41,6 +41,9 @@ export function SimulationTab() {
       Object.entries(result.benchmarkReturnRates ?? {}).map(([ticker, value]) => [ticker, Number(value.toFixed(2))])
     ),
   })) ?? [];
+  const latestPortfolioReturnRate = simulation.data?.dailyResults.length
+    ? simulation.data.dailyResults[simulation.data.dailyResults.length - 1].portfolioReturnRate
+    : 0;
 
   return (
     <div className="px-4 py-4 space-y-4">
@@ -111,7 +114,7 @@ export function SimulationTab() {
             <div className="mt-4 grid grid-cols-2 gap-2">
               <BenchmarkSummaryCard
                 label="내 포트폴리오"
-                returnRate={simulation.data?.dailyResults.at(-1)?.portfolioReturnRate ?? 0}
+                returnRate={latestPortfolioReturnRate ?? 0}
                 emphasize
               />
               {simulation.data?.comparisons.map((comparison) => (
@@ -145,8 +148,8 @@ function BenchmarkSummaryCard({
   return (
     <div className={`rounded-xl border px-3 py-3 ${emphasize ? "border-primary/30 bg-primary/5" : "border-border bg-background/40"}`}>
       <p className="text-xs text-muted-foreground">{label}</p>
-      <p className={`mt-1 text-sm font-semibold tabular-nums ${returnRate >= 0 ? "text-up" : "text-down"}`}>
-        {formatPercent(returnRate)}
+      <p className="mt-1 text-sm font-semibold">
+        <SignedValueLabel value={returnRate} format="percent" ariaLabelPrefix={`${label} 수익률`} />
       </p>
     </div>
   );

--- a/src/app/components/portfolio/widgets/RebalancingWidget.tsx
+++ b/src/app/components/portfolio/widgets/RebalancingWidget.tsx
@@ -1,6 +1,7 @@
 import { usePortfolioSummary } from "@/hooks/use-portfolio";
-import { formatPercent } from "@/utils/format";
+import { formatSignedPercent } from "@/utils/format";
 import { Skeleton } from "@/app/components/ui";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { AIAdviceWidget } from "./AIAdviceWidget";
 import { RebalancingItem } from "@/types/api";
 
@@ -66,24 +67,19 @@ export function RebalancingWidget() {
               <div className="flex-1">
                 <p className="text-muted-foreground text-[10px] mb-1">현재 비중</p>
                 <p className="text-foreground font-semibold text-sm">
-                  {formatPercent(item.currentWeight)}
+                  {formatSignedPercent(item.currentWeight, { showArrow: false, showSign: false })}
                 </p>
               </div>
               <div className="flex-1">
                 <p className="text-muted-foreground text-[10px] mb-1">목표 비중</p>
                 <p className="text-foreground font-semibold text-sm">
-                  {formatPercent(item.targetWeight)}
+                  {formatSignedPercent(item.targetWeight, { showArrow: false, showSign: false })}
                 </p>
               </div>
               <div className="flex-1">
                 <p className="text-muted-foreground text-[10px] mb-1">차이</p>
-                <p
-                  className={`font-semibold text-sm ${
-                    item.diffWeight > 0 ? "text-up" : "text-down"
-                  }`}
-                >
-                  {item.diffWeight > 0 ? "+" : ""}
-                  {formatPercent(item.diffWeight)}
+                <p className="font-semibold text-sm">
+                  <SignedValueLabel value={item.diffWeight} format="percent" ariaLabelPrefix={`${item.name} 비중 차이`} />
                 </p>
               </div>
             </div>

--- a/src/app/components/portfolio/widgets/SimulationWidget.tsx
+++ b/src/app/components/portfolio/widgets/SimulationWidget.tsx
@@ -17,7 +17,8 @@ import {
   Legend,
 } from "recharts";
 import { format } from "date-fns";
-import { Loader2, TrendingUp, TrendingDown } from "lucide-react";
+import { Loader2 } from "lucide-react";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 
 const PERIOD_OPTIONS: { label: string; value: ChartPeriod }[] = [
   { label: "1M", value: "1M" },
@@ -88,24 +89,24 @@ export function SimulationWidget() {
         <div className="grid grid-cols-2 gap-3">
           <MetricCard
             label="누적 수익률"
-            value={`${metrics.totalReturn}%`}
-            isPositive={metrics.totalReturn >= 0}
+            value={metrics.totalReturn}
+            signed
           />
           <MetricCard
             label="연평균 (CAGR)"
-            value={`${metrics.cagr}%`}
-            isPositive={metrics.cagr >= 0}
+            value={metrics.cagr}
+            signed
           />
           <MetricCard
             label="최대 낙폭 (MDD)"
-            value={`${metrics.mdd}%`}
-            isNegative={true}
+            value={metrics.mdd}
+            signed
           />
-          <MetricCard label="샤프 지수" value={metrics.sharpeRatio.toString()} />
-          <MetricCard label="소르티노 지수" value={metrics.sortinoRatio.toString()} />
+          <MetricCard label="샤프 지수" value={metrics.sharpeRatio?.toString() ?? "-"} />
+          <MetricCard label="소르티노 지수" value={metrics.sortinoRatio?.toString() ?? "0"} />
           <MetricCard
             label="시장 민감도 (Beta)"
-            value={metrics.beta.toString()}
+            value={metrics.beta?.toString() ?? "-"}
           />
           <MetricCard
             label="최장 회복 기간"
@@ -150,9 +151,7 @@ export function SimulationWidget() {
                             />
                             <span className="text-muted-foreground">{entry.name}</span>
                           </div>
-                          <span className={Number(entry.value) >= 0 ? "text-emerald-600 font-bold" : "text-rose-600 font-bold"}>
-                            {entry.value}%
-                          </span>
+                          <SignedValueLabel value={Number(entry.value)} format="percent" className="font-bold" />
                         </div>
                       ))}
                     </div>
@@ -200,13 +199,11 @@ export function SimulationWidget() {
 function MetricCard({
   label,
   value,
-  isPositive,
-  isNegative,
+  signed = false,
 }: {
   label: string;
-  value: string;
-  isPositive?: boolean;
-  isNegative?: boolean;
+  value: string | number;
+  signed?: boolean;
 }) {
   return (
     <Card className="border shadow-none bg-muted/10">
@@ -215,15 +212,11 @@ function MetricCard({
           {label}
         </p>
         <div className="flex items-center gap-1">
-          <span
-            className={`text-sm font-bold ${
-              isPositive ? "text-emerald-600" : isNegative ? "text-rose-600" : "text-foreground"
-            }`}
-          >
-            {value}
-          </span>
-          {isPositive && <TrendingUp className="h-3 w-3 text-emerald-600" />}
-          {isNegative && <TrendingDown className="h-3 w-3 text-rose-600" />}
+          {signed ? (
+            <SignedValueLabel value={value} format="percent" className="text-sm font-bold" />
+          ) : (
+            <span className="text-sm font-bold text-foreground">{value}</span>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/app/components/screens/BacktestResult.tsx
+++ b/src/app/components/screens/BacktestResult.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { Activity, Sparkles, Printer } from "lucide-react";
-import { XAxis, Tooltip, ResponsiveContainer, ComposedChart, Line, ReferenceArea } from "recharts";
+import { XAxis, Tooltip, ResponsiveContainer, ComposedChart, Line } from "recharts";
 import { useBacktest } from "@/hooks/use-backtest";
 import { BacktestDailyResult } from "@/types/api";
 import { Skeleton, Badge } from "@/app/components/ui";
 import { PageHeader } from "@/app/components/shared";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 
 export function BacktestResult() {
   const navigate = useNavigate();
@@ -185,7 +186,9 @@ export function BacktestResult() {
           </div>
           <div className="mb-2 font-medium text-muted-foreground">{(config.amount || 0).toLocaleString()}원이</div>
           <div className="mb-3 text-[length:var(--mobile-number-xl)] font-bold text-foreground md:text-5xl">₩ {finalValue.toLocaleString()}</div>
-          <div className="mb-4 text-[2rem] font-bold text-up md:text-3xl">{totalReturn >= 0 ? "+" : ""}{totalReturn}%</div>
+          <div className="mb-4 text-[2rem] font-bold md:text-3xl">
+            <SignedValueLabel value={totalReturn} format="percent" fractionDigits={1} ariaLabelPrefix="총 수익률" />
+          </div>
           <div className="font-medium text-muted-foreground">되었을 거예요!</div>
 
           <div className="mt-6 rounded-3xl border border-border bg-card p-5 shadow-sm">
@@ -197,8 +200,8 @@ export function BacktestResult() {
               <div className="text-right">
                 {hasBenchmarkReturn ? (
                   <>
-                    <div className="text-[1.75rem] font-bold text-up md:text-3xl">
-                      {outperformance >= 0 ? "+" : ""}{outperformance.toFixed(1)}%
+                    <div className="text-[1.75rem] font-bold md:text-3xl">
+                      <SignedValueLabel value={outperformance} format="percent" fractionDigits={1} ariaLabelPrefix="벤치마크 대비 수익률" />
                     </div>
                     <div className="text-sm font-medium text-muted-foreground">더 높은 수익</div>
                   </>
@@ -216,8 +219,8 @@ export function BacktestResult() {
         <section className="rounded-[32px] border border-border bg-card px-5 py-6 shadow-[0_18px_42px_-36px_rgba(15,23,42,0.28)]">
           <div className="text-foreground mb-6 font-bold text-xl md:text-2xl">상세 성과 지표</div>
           <div className="grid grid-cols-2 gap-4">
-            <MetricCard label="연평균 수익률" value={displayCagr != null ? `${displayCagr}%` : "-"} sub="CAGR" color="text-up" />
-            <MetricCard label="최대 낙폭" value={displayMdd != null ? `${displayMdd}%` : "-"} sub="MDD" color="text-down" />
+            <MetricCard label="연평균 수익률" value={displayCagr != null ? <SignedValueLabel value={displayCagr} format="percent" /> : "-"} sub="CAGR" />
+            <MetricCard label="최대 낙폭" value={displayMdd != null ? <SignedValueLabel value={displayMdd} format="percent" /> : "-"} sub="MDD" />
             <MetricCard label="위험 대비 수익" value={displaySharpe ?? "-"} sub="샤프 지수" />
             <MetricCard label="하락 변동성 대비 수익" value={metrics.sortinoRatio?.toString() ?? "0"} sub="소르티노 지수" />
             <MetricCard label="시장 민감도" value={displayBeta ?? "-"} sub="Beta" />
@@ -225,17 +228,15 @@ export function BacktestResult() {
             {displayBestYear != null && (
               <MetricCard
                 label={yearlyStats.best?.year ? `최고 연도 (${yearlyStats.best.year})` : "최고 연도"}
-                value={`${displayBestYear > 0 ? "▲ " : "▼ "}${Math.abs(displayBestYear)}%`}
+                value={<SignedValueLabel value={displayBestYear} format="percent" fractionDigits={1} />}
                 sub="Best Year"
-                color="text-up"
               />
             )}
             {displayWorstYear != null && (
               <MetricCard
                 label={yearlyStats.worst?.year ? `최저 연도 (${yearlyStats.worst.year})` : "최저 연도"}
-                value={`${displayWorstYear}%`}
+                value={<SignedValueLabel value={displayWorstYear} format="percent" fractionDigits={1} />}
                 sub="Worst Year"
-                color="text-down"
               />
             )}
           </div>
@@ -245,11 +246,11 @@ export function BacktestResult() {
   );
 }
 
-function MetricCard({ label, value, sub, color = "text-foreground" }: { label: string; value: string; sub: string; color?: string }) {
+function MetricCard({ label, value, sub }: { label: string; value: ReactNode; sub: string }) {
   return (
     <div className="rounded-2xl bg-secondary/30 p-4">
       <div className="mb-1 text-xs font-medium text-muted-foreground">{label}</div>
-      <div className={`mb-1 text-lg font-bold ${color}`}>{value}</div>
+      <div className="mb-1 text-lg font-bold text-foreground">{value}</div>
       <div className="text-[10px] text-muted-foreground opacity-60 uppercase tracking-wider">{sub}</div>
     </div>
   );
@@ -283,8 +284,12 @@ function ChartSection({ backtestData }: { backtestData: BacktestDailyResult[] })
                   return (
                     <div className="rounded-2xl border border-border bg-card/90 p-3 shadow-xl backdrop-blur-md">
                       <div className="mb-1 text-xs text-muted-foreground">{data.date}</div>
-                      <div className="text-sm font-bold text-up">수익률: {data.return.toFixed(1)}%</div>
-                      <div className="text-xs text-muted-foreground">벤치마크: {data.bench.toFixed(1)}%</div>
+                      <div className="text-sm font-bold">
+                        수익률: <SignedValueLabel value={data.return} format="percent" fractionDigits={1} />
+                      </div>
+                      <div className="text-xs">
+                        벤치마크: <SignedValueLabel value={data.bench} format="percent" fractionDigits={1} />
+                      </div>
                     </div>
                   );
                 }

--- a/src/app/components/screens/Home.tsx
+++ b/src/app/components/screens/Home.tsx
@@ -7,6 +7,7 @@ import { ContextHeader, GardenEmptyState, Section } from "@/app/components/share
 import { useAuthStore } from "@/store/auth";
 import { useMarketIndex } from "@/hooks/use-market-index";
 import { MarketIndexSection } from "@/app/components/home/MarketIndexCard";
+import { MarketWeatherWidget } from "@/app/components/home/MarketWeatherWidget";
 import { getMarketWeatherPresentation } from "@/app/components/home/market-weather-presentation";
 import { StockSupplyRankingSection } from "@/app/components/home/StockSupplyRankingSection";
 import { SectorRankingSection } from "@/app/components/home/SectorRankingSection";
@@ -18,50 +19,19 @@ export function Home() {
   const nickname = useAuthStore((state) => state.nickname);
   const { data: marketDashboard, isLoading, isError } = useMarketIndex();
   const [selectedSector, setSelectedSector] = useState<SectorData | null>(null);
-  const greeting = getMarketWeatherPresentation(marketDashboard?.weather, isLoading, isError);
 
   return (
     <div className="min-h-full pb-6">
-      <div className="page-shell page-content pt-4 md:pt-6">
-        <ContextHeader
-          variant="market"
-          layout="split"
-          title={
-            <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
-              <p className="max-w-[15rem] text-[length:var(--mobile-hero-title-size)] font-bold leading-[1.08] tracking-tight min-[408px]:max-w-[17rem] md:max-w-[24rem] md:text-[32px]">
-                {nickname ?? "투자자"}님,
-                <br />
-                {greeting.text} {greeting.emoji}
-              </p>
-            </motion.div>
-          }
-          description="오늘 시장 요약을 빠르게 확인하고 다음 탐색을 시작할 수 있도록 정리했습니다."
-          actions={
-            <div className="relative z-20">
-              <button
-                onClick={() => navigate("/more/notifications")}
-                className="rounded-full border border-border/70 bg-card/80 p-2 text-muted-foreground transition-colors hover:bg-card"
-              >
-                <Bell className="h-5 w-5" />
-              </button>
-            </div>
-          }
-        />
+      <div className="page-shell page-content pt-4 md:pt-6 flex justify-end">
+        <button
+          onClick={() => navigate("/more/notifications")}
+          className="rounded-full border border-border/70 bg-card/80 p-2 text-muted-foreground transition-colors hover:bg-card"
+        >
+          <Bell className="h-5 w-5" />
+        </button>
       </div>
 
-      <Section
-        title="시장 현황"
-        subtitle="대표 지수 흐름을 먼저 확인하고 오늘의 투자 감도를 맞춥니다."
-        icon={BarChart2}
-        className="pt-6"
-        rightContent={
-          <Button variant="ghost" size="sm" className="text-xs" onClick={() => navigate("/search")}>
-            시장 탐색
-          </Button>
-        }
-      >
-        <MarketIndexSection />
-      </Section>
+      <MarketWeatherWidget />
 
       <Section
         title="오늘의 주목 섹터"

--- a/src/app/components/screens/More.tsx
+++ b/src/app/components/screens/More.tsx
@@ -18,8 +18,8 @@ import { usePortfolio } from "@/hooks/use-portfolio";
 import { useWithdraw, useUpdateProfile } from "@/hooks/use-member";
 import { useAuthStore } from "@/store/auth";
 import { calculateInvestorType } from "@/utils/calculate";
-import { formatPercent } from "@/utils/format";
 import { getTrendClassName } from "@/utils/trend";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 
 export function More() {
   const navigate = useNavigate();
@@ -86,10 +86,9 @@ export function More() {
               <MetricTile label="보유 종목" value={`${holdings?.items?.length ?? "—"}개`} />
               <MetricTile
                 label="총 수익률"
-                value={
-                  valuation?.totalReturnRate != null
-                    ? formatPercent(valuation.totalReturnRate)
-                    : "—"
+                value={valuation?.totalReturnRate != null
+                  ? <SignedValueLabel value={valuation.totalReturnRate} format="percent" ariaLabelPrefix="총 수익률" />
+                  : "—"
                 }
                 tone={
                   valuation?.totalReturnRate != null
@@ -309,7 +308,7 @@ function MetricTile({
   icon,
 }: {
   label: string;
-  value: string;
+  value: ReactNode;
   tone?: "neutral" | "up" | "down";
   icon?: ReactNode;
 }) {

--- a/src/app/components/screens/Portfolio.tsx
+++ b/src/app/components/screens/Portfolio.tsx
@@ -19,6 +19,7 @@ import {
   Skeleton,
 } from "@/app/components/ui";
 import { cn } from "@/app/components/ui/utils";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { PortfolioBottomSheet, AnalysisType } from "@/app/components/portfolio/PortfolioBottomSheet";
 import { PortfolioEditSheet } from "@/app/components/portfolio/PortfolioEditSheet";
 import { PortfolioHoldingsSheet } from "@/app/components/portfolio/PortfolioHoldingsSheet";
@@ -29,7 +30,6 @@ import { useAuthStore } from "@/store/auth";
 import { PortfolioItemResponse, RebalancingItem } from "@/types/api";
 import { calculateHealthBadge, calculateInvestorType } from "@/utils/calculate";
 import { formatCurrency, formatDate } from "@/utils/format";
-import { getTrendClassName } from "@/utils/trend";
 
 const PERFORMANCE_OPTIONS = ["1M", "3M", "6M", "1Y"] as const;
 type PerformancePeriod = (typeof PERFORMANCE_OPTIONS)[number];
@@ -170,13 +170,32 @@ export function Portfolio() {
                 ₩{formatCurrency(valuation?.currentTotalValue ?? 0)}
               </p>
               <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-                <span className={getToneClassName(valuation?.totalReturnRate ?? 0, "text-sm font-semibold tabular-nums")}>
-                  ₩{formatCurrency(Math.abs(valuation?.totalProfitLoss ?? 0))} {Math.abs(valuation?.totalReturnRate ?? 0).toFixed(2)}%
+                <span className="text-sm font-semibold tabular-nums">
+                  <SignedValueLabel
+                    value={valuation?.totalProfitLoss ?? 0}
+                    format="currency"
+                    ariaLabelPrefix="누적 평가손익"
+                  />{" "}
+                  <SignedValueLabel
+                    value={valuation?.totalReturnRate ?? 0}
+                    format="percent"
+                    ariaLabelPrefix="누적 수익률"
+                  />
                 </span>
                 <span className="text-muted-foreground text-xs">누적</span>
                 <span className="text-border">•</span>
-                <span className={getToneClassName(valuation?.dailyReturnRate ?? 0, "text-xs tabular-nums")}>
-                  오늘 ₩{formatCurrency(Math.abs(valuation?.dailyProfitLoss ?? 0))} {Math.abs(valuation?.dailyReturnRate ?? 0).toFixed(2)}%
+                <span className="text-xs tabular-nums">
+                  오늘{" "}
+                  <SignedValueLabel
+                    value={valuation?.dailyProfitLoss ?? 0}
+                    format="currency"
+                    ariaLabelPrefix="오늘 평가손익"
+                  />{" "}
+                  <SignedValueLabel
+                    value={valuation?.dailyReturnRate ?? 0}
+                    format="percent"
+                    ariaLabelPrefix="오늘 수익률"
+                  />
                 </span>
               </div>
             </div>
@@ -258,12 +277,12 @@ export function Portfolio() {
                         return "모든 주요 지수보다 높은 성과를 내고 있습니다! ✨";
                       } else if (betterThan.length > 0) {
                         const bestBench = betterThan.sort((a, b) => b.totalReturn - a.totalReturn)[0];
-                        const diff = (myTotalReturn - bestBench.totalReturn).toFixed(1);
-                        return `${BENCHMARK_LABELS[bestBench.ticker] || bestBench.indexName}보다 ${diff}% 더 높은 수익을 기록 중이에요! 🚀`;
+                        const diff = myTotalReturn - bestBench.totalReturn;
+                        return `${BENCHMARK_LABELS[bestBench.ticker] || bestBench.indexName}보다 ${formatSignedPercentText(diff)} 더 높은 수익을 기록 중이에요! 🚀`;
                       } else {
                         const bestOverall = [...comparisons].sort((a, b) => b.totalReturn - a.totalReturn)[0];
-                        const diff = (bestOverall.totalReturn - myTotalReturn).toFixed(1);
-                        return `${BENCHMARK_LABELS[bestOverall.ticker] || bestOverall.indexName} 대비 ${diff}% 차이로 바짝 추격하고 있어요. 🔥`;
+                        const diff = myTotalReturn - bestOverall.totalReturn;
+                        return `${BENCHMARK_LABELS[bestOverall.ticker] || bestOverall.indexName} 대비 ${formatSignedPercentText(diff)} 차이로 바짝 추격하고 있어요. 🔥`;
                       }
                     })()}
                   </span>
@@ -427,9 +446,13 @@ function PerformanceBar({
         <span className={cn("font-medium", isPortfolio ? "text-foreground font-bold" : "text-muted-foreground")}>
           {label}
         </span>
-        <span className={cn("font-bold tabular-nums", isZero ? "text-muted-foreground/50" : getTrendClassName(value))}>
-          {Math.abs(value).toFixed(1)}%
-        </span>
+        <SignedValueLabel
+          value={value}
+          format="percent"
+          fractionDigits={1}
+          className={cn("font-bold", isZero && "text-muted-foreground/50")}
+          ariaLabelPrefix={`${label} 수익률`}
+        />
       </div>
       <div className="h-2 w-full bg-secondary/30 rounded-full overflow-hidden">
         {isZero ? (
@@ -472,8 +495,8 @@ function HoldingRow({
           <p className="text-sm font-semibold text-foreground tabular-nums">
             ₩{formatCurrency(item.currentValue ?? 0)}
           </p>
-          <p className={getToneClassName(item.returnRate ?? 0, "text-xs tabular-nums")}>
-            {Math.abs(item.returnRate ?? 0).toFixed(2)}%
+          <p className="text-xs">
+            <SignedValueLabel value={item.returnRate ?? 0} format="percent" ariaLabelPrefix={`${item.name || item.symbol} 수익률`} />
           </p>
         </div>
       </div>
@@ -525,8 +548,9 @@ function SecondaryActionCard({
   );
 }
 
-function getToneClassName(value: number, baseClassName: string) {
-  return `${baseClassName} ${getTrendClassName(value, { neutral: "text-foreground" })}`;
+function formatSignedPercentText(value: number) {
+  const prefix = value > 0 ? "▲ " : value < 0 ? "▼ " : "";
+  return `${prefix}${Math.abs(value).toFixed(1)}%`;
 }
 
 function getAdviceSummary(content: string | undefined) {

--- a/src/app/components/screens/StockDetail.tsx
+++ b/src/app/components/screens/StockDetail.tsx
@@ -9,7 +9,8 @@ import { useWatchlist } from "@/hooks/use-watchlist";
 import { useAuthStore } from "@/store/auth";
 import { Skeleton, Dialog, DialogContent, DialogHeader, DialogTitle } from "@/app/components/ui";
 import { PageHeader } from "@/app/components/shared";
-import { formatCurrency, formatPercent } from "@/utils/format";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
+import { formatCurrency } from "@/utils/format";
 import { StockReturnsResponse } from "@/api/stock";
 import { ChartPeriod, ChartFrequency } from "@/types/api";
 import { toast } from "sonner";
@@ -219,7 +220,7 @@ export function StockDetail() {
         
         // 날짜가 정확히 일치하지 않으면 해당 날짜 이전의 가장 가까운 벤치마크 데이터를 찾음
         if (returnRate === undefined && sortedBenchmarkDates.length > 0) {
-          const closestDate = sortedBenchmarkDates.findLast(date => date <= p.date);
+          const closestDate = findClosestDate(sortedBenchmarkDates, p.date);
           if (closestDate) {
             returnRate = benchmarkMap.get(closestDate);
           }
@@ -406,8 +407,14 @@ export function StockDetail() {
   );
 }
 
+function findClosestDate(dates: string[], targetDate: string) {
+  for (let i = dates.length - 1; i >= 0; i -= 1) {
+    if (dates[i] <= targetDate) return dates[i];
+  }
+  return undefined;
+}
+
 function PriceSection({ ticker, stockName, latestPrice, dailyRate }: PriceSectionProps) {
-  const isUp = dailyRate != null && dailyRate >= 0;
   return (
     <section className="page-shell page-content py-6">
       <div className="overflow-hidden rounded-[32px] border border-border bg-[linear-gradient(180deg,color-mix(in_srgb,var(--color-primary)_10%,var(--color-card)),var(--color-card))] px-5 py-6 shadow-[0_22px_56px_-42px_rgba(15,23,42,0.38)]">
@@ -419,8 +426,8 @@ function PriceSection({ ticker, stockName, latestPrice, dailyRate }: PriceSectio
         {stockName && <div className="mb-2 text-lg font-bold text-foreground">{stockName}</div>}
         <div className="mb-2 text-[length:var(--mobile-number-xl)] font-bold text-foreground md:text-5xl">₩{formatCurrency(latestPrice)}</div>
         {dailyRate != null && (
-          <div className={`text-lg font-bold ${isUp ? "text-up" : "text-down"}`}>
-            어제보다 {formatPercent(dailyRate)}
+          <div className="text-lg font-bold">
+            어제보다 <SignedValueLabel value={dailyRate} format="percent" ariaLabelPrefix={`${stockName || ticker} 일간 등락률`} />
           </div>
         )}
         <div className="mt-5 rounded-[24px] border border-border/70 bg-card/80 px-4 py-4">
@@ -680,7 +687,6 @@ function ComparisonSection({ returnsData }: ComparisonSectionProps) {
           {returnsData.map(({ label, data, isLoading }) => {
             const stockRate = data?.stockReturnRate;
             const benchRate = data?.benchmarkReturnRate;
-            const isUp = stockRate != null && stockRate >= 0;
             return (
               <div key={label} className="grid grid-cols-3 items-center py-3 border-t border-border">
                 <span className="text-muted-foreground font-medium text-sm">{label}</span>
@@ -691,12 +697,12 @@ function ComparisonSection({ returnsData }: ComparisonSectionProps) {
                   </>
                 ) : (
                   <>
-                    <span className={`text-center font-bold text-sm ${isUp ? "text-up" : "text-down"}`}>
-                      {stockRate != null ? formatPercent(stockRate) : "-"}
+                    <span className="text-center font-bold text-sm">
+                      <SignedValueLabel value={stockRate} format="percent" ariaLabelPrefix={`${label} 종목 수익률`} fallback="-" />
                     </span>
-                    <span className="text-right font-bold text-sm text-foreground">
+                    <span className="text-right font-bold text-sm">
                       {benchRate != null
-                        ? formatPercent(benchRate)
+                        ? <SignedValueLabel value={benchRate} format="percent" ariaLabelPrefix={`${label} 벤치마크 수익률`} />
                         : <span className="text-muted-foreground font-medium">데이터 없음</span>}
                     </span>
                   </>

--- a/src/app/components/shared/label/PriceTrendLabel.tsx
+++ b/src/app/components/shared/label/PriceTrendLabel.tsx
@@ -1,6 +1,5 @@
 import { motion } from "motion/react";
-import { formatPercent } from "@/utils/format";
-import { getTrendClassName, getTrendTone } from "@/utils/trend";
+import { SignedValueLabel } from "./SignedValueLabel";
 
 interface PriceTrendLabelProps {
   change: number;
@@ -10,18 +9,15 @@ interface PriceTrendLabelProps {
 }
 
 export function PriceTrendLabel({ change, returnRate, className = "", showIcon = true }: PriceTrendLabelProps) {
-  const status = getTrendTone(change);
-  const colorClass = getTrendClassName(change);
-  const icon = status === 'up' ? "🔺" : status === 'down' ? "🔻" : "";
+  const label = change > 0 ? "가격 상승률" : change < 0 ? "가격 하락률" : "가격 보합률";
 
   return (
     <motion.div 
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className={`flex items-center gap-1 font-bold ${colorClass} ${className}`}
+      className={`flex items-center gap-1 font-bold ${className}`}
     >
-      <span>{formatPercent(returnRate)}</span>
-      {showIcon && icon && <span>{icon}</span>}
+      <SignedValueLabel value={returnRate} format="percent" showArrow={showIcon} ariaLabelPrefix={label} />
     </motion.div>
   );
 }

--- a/src/app/components/shared/label/SignedValueLabel.tsx
+++ b/src/app/components/shared/label/SignedValueLabel.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/app/components/ui/utils";
+import { formatSignedCurrency, formatSignedNumber, formatSignedPercent, toFiniteNumber } from "@/utils/format";
+import { getTrendClassName, getTrendTone } from "@/utils/trend";
+
+type SignedValueFormat = "percent" | "currency" | "number";
+
+interface SignedValueLabelProps {
+  value: number | string | null | undefined;
+  format: SignedValueFormat;
+  className?: string;
+  showArrow?: boolean;
+  showSign?: boolean;
+  fractionDigits?: number;
+  ariaLabelPrefix?: string;
+  fallback?: string;
+}
+
+export function SignedValueLabel({
+  value,
+  format,
+  className,
+  showArrow = true,
+  showSign = false,
+  fractionDigits,
+  ariaLabelPrefix,
+  fallback,
+}: SignedValueLabelProps) {
+  if (fallback !== undefined && (value === null || value === undefined || Number.isNaN(Number(value)))) {
+    return <span className={cn("text-muted-foreground tabular-nums", className)}>{fallback}</span>;
+  }
+
+  const num = toFiniteNumber(value);
+  const tone = getTrendTone(num);
+  const directionLabel = tone === "up" ? "상승" : tone === "down" ? "하락" : "보합";
+  const text = formatSignedValue(format, value, {
+    showArrow,
+    showSign,
+    fractionDigits,
+  });
+  const ariaLabel = ariaLabelPrefix ? `${ariaLabelPrefix} ${directionLabel} ${text}` : `${directionLabel} ${text}`;
+
+  return (
+    <span className={cn("tabular-nums", getTrendClassName(num), className)} aria-label={ariaLabel}>
+      {text}
+    </span>
+  );
+}
+
+function formatSignedValue(
+  format: SignedValueFormat,
+  value: number | string | null | undefined,
+  options: {
+    showArrow: boolean;
+    showSign: boolean;
+    fractionDigits?: number;
+  },
+) {
+  if (format === "currency") return formatSignedCurrency(value, options);
+  if (format === "number") return formatSignedNumber(value, options);
+  return formatSignedPercent(value, options);
+}

--- a/src/app/components/shared/label/__tests__/SignedValueLabel.test.tsx
+++ b/src/app/components/shared/label/__tests__/SignedValueLabel.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SignedValueLabel } from "../SignedValueLabel";
+
+describe("SignedValueLabel", () => {
+  it("renders signed percent labels with arrows", () => {
+    render(
+      <div>
+        <SignedValueLabel value={1.24} format="percent" ariaLabelPrefix="등락률" />
+        <SignedValueLabel value={-0.82} format="percent" ariaLabelPrefix="등락률" />
+        <SignedValueLabel value={0} format="percent" ariaLabelPrefix="등락률" />
+      </div>,
+    );
+
+    expect(screen.getByText("▲ 1.24%")).toBeInTheDocument();
+    expect(screen.getByText("▼ 0.82%")).toBeInTheDocument();
+    expect(screen.getByText("0.00%")).toBeInTheDocument();
+  });
+
+  it("includes direction in the accessible label", () => {
+    render(<SignedValueLabel value={1.24} format="percent" ariaLabelPrefix="삼성전자 등락률" />);
+
+    expect(screen.getByLabelText("삼성전자 등락률 상승 ▲ 1.24%")).toBeInTheDocument();
+  });
+
+  it("uses fallback for missing values", () => {
+    render(<SignedValueLabel value={null} format="percent" fallback="-" />);
+
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+});

--- a/src/app/components/watchlist/WatchlistItemCard.tsx
+++ b/src/app/components/watchlist/WatchlistItemCard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 import { X } from "lucide-react";
 import { motion, AnimatePresence, useMotionValue, useTransform, animate } from "motion/react";
 import { WatchlistItemDetail } from "@/types/api";
-import { formatPercent } from "@/utils/format";
+import { SignedValueLabel } from "@/app/components/shared/label/SignedValueLabel";
 import { useWatchlist } from "@/hooks/use-watchlist";
 import { toast } from "sonner";
 
@@ -155,10 +155,13 @@ export function WatchlistItemCard({
               <p className="text-sm font-semibold text-foreground tabular-nums">
                 {stock.currentPrice !== null ? `₩${stock.currentPrice.toLocaleString()}` : "-"}
               </p>
-              <p
-                className={`text-xs font-medium tabular-nums ${stock.fluctuationRate !== null && stock.fluctuationRate >= 0 ? "text-up" : stock.fluctuationRate !== null ? "text-down" : "text-muted-foreground"}`}
-              >
-                {stock.fluctuationRate !== null ? formatPercent(stock.fluctuationRate) : "-"}
+              <p className="text-xs font-medium">
+                <SignedValueLabel
+                  value={stock.fluctuationRate}
+                  format="percent"
+                  ariaLabelPrefix={`${stock.name} 등락률`}
+                  fallback="-"
+                />
               </p>
             </div>
           </div>

--- a/src/hooks/use-market-weather.ts
+++ b/src/hooks/use-market-weather.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { marketWeatherApi, marketWeatherKeys } from "@/api/marketWeatherApi";
+
+/**
+ * 증시 기상도 데이터를 관리하는 커스텀 훅
+ */
+export function useMarketWeather() {
+  return useQuery({
+    queryKey: marketWeatherKeys.latest(),
+    queryFn: () => marketWeatherApi.getLatest(),
+    staleTime: 10 * 60 * 1000, // 10분 동안 신선한 데이터로 간주
+  });
+}

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatSignedCurrency, formatSignedNumber, formatSignedPercent } from "../format";
+
+describe("signed value formatters", () => {
+  it("formats signed percent values with Korean market arrows", () => {
+    expect(formatSignedPercent(1.24)).toBe("▲ 1.24%");
+    expect(formatSignedPercent(-0.82)).toBe("▼ 0.82%");
+    expect(formatSignedPercent(0)).toBe("0.00%");
+    expect(formatSignedPercent(null)).toBe("0.00%");
+    expect(formatSignedPercent(Number.NaN)).toBe("0.00%");
+  });
+
+  it("formats signed currency values with won text units", () => {
+    expect(formatSignedCurrency(12500)).toBe("12,500 원");
+    expect(formatSignedCurrency(-8100)).toBe("8,100 원");
+    expect(formatSignedCurrency(0)).toBe("0 원");
+  });
+
+  it("can omit arrows and signs when a compact context needs plain numbers", () => {
+    expect(formatSignedPercent(12.3, { showArrow: false, showSign: false })).toBe("12.30%");
+    expect(formatSignedNumber(-1234, { showArrow: false, showSign: false })).toBe("1,234");
+  });
+});

--- a/src/utils/__tests__/trend.test.ts
+++ b/src/utils/__tests__/trend.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getTrendClassName, getTrendTone } from "../trend";
+
+describe("trend helpers", () => {
+  it("maps signed values to the shared financial tones", () => {
+    expect(getTrendTone(1)).toBe("up");
+    expect(getTrendTone(-1)).toBe("down");
+    expect(getTrendTone(0)).toBe("neutral");
+  });
+
+  it("returns red/up, blue/down, and neutral classes", () => {
+    expect(getTrendClassName(1)).toBe("text-up");
+    expect(getTrendClassName(-1)).toBe("text-down");
+    expect(getTrendClassName(0)).toBe("text-muted-foreground");
+  });
+});
+

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -3,22 +3,65 @@ export const formatCurrency = (value: number | null | undefined): string => {
   return value.toLocaleString('ko-KR');
 };
 
-export const formatPercent = (value: number | string | null | undefined): string => {
-  if (value === null || value === undefined) return '0.00%';
-  const num = typeof value === 'string' ? parseFloat(value) : value;
-  if (isNaN(num)) return '0.00%';
-  
-  // 0%일 경우 부호 없이 출력
-  if (Math.abs(num) < 0.0001) return '0.00%';
-  
-  const sign = num > 0 ? '▲ ' : '▼ ';
-  return `${sign}${Math.abs(num).toFixed(2)}%`;
+export type SignedFormatOptions = {
+  showArrow?: boolean;
+  showSign?: boolean;
+  fractionDigits?: number;
 };
 
-export const formatSignedCurrency = (value: number | null | undefined): string => {
-  const amount = value ?? 0;
-  const prefix = amount > 0 ? "+" : amount < 0 ? "-" : "";
-  return `${prefix}₩${formatCurrency(Math.abs(amount))}`;
+export const toFiniteNumber = (value: number | string | null | undefined): number => {
+  if (value === null || value === undefined) return 0;
+  const num = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isFinite(num) ? num : 0;
+};
+
+export const formatSignedPercent = (
+  value: number | string | null | undefined,
+  options: SignedFormatOptions = {},
+): string => {
+  const { showArrow = true, showSign = false, fractionDigits = 2 } = options;
+  const num = toFiniteNumber(value);
+
+  if (Math.abs(num) < 0.0001) return '0.00%';
+
+  const arrow = showArrow ? (num > 0 ? '▲ ' : '▼ ') : '';
+  const sign = showSign ? (num > 0 ? '+' : '-') : '';
+  return `${arrow}${sign}${Math.abs(num).toFixed(fractionDigits)}%`;
+};
+
+export const formatPercent = (value: number | string | null | undefined): string => {
+  return formatSignedPercent(value);
+};
+
+export const formatSignedCurrency = (
+  value: number | string | null | undefined,
+  options: SignedFormatOptions = {},
+): string => {
+  const { showArrow = false, showSign = false } = options;
+  const amount = toFiniteNumber(value);
+
+  if (Math.abs(amount) < 0.0001) return '0 원';
+
+  const arrow = showArrow ? (amount > 0 ? '▲ ' : '▼ ') : '';
+  const sign = showSign ? (amount > 0 ? '+' : '-') : '';
+  return `${arrow}${sign}${formatCurrency(Math.abs(amount))} 원`;
+};
+
+export const formatSignedNumber = (
+  value: number | string | null | undefined,
+  options: SignedFormatOptions = {},
+): string => {
+  const { showArrow = true, showSign = false, fractionDigits = 0 } = options;
+  const num = toFiniteNumber(value);
+
+  if (Math.abs(num) < 0.0001) return fractionDigits > 0 ? num.toFixed(fractionDigits) : '0';
+
+  const arrow = showArrow ? (num > 0 ? '▲ ' : '▼ ') : '';
+  const sign = showSign ? (num > 0 ? '+' : '-') : '';
+  return `${arrow}${sign}${Math.abs(num).toLocaleString('ko-KR', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })}`;
 };
 
 export const formatDate = (date: string | Date): string => {


### PR DESCRIPTION
## 📝 개요
홈 화면의 기상도 위젯을 7단계 UI로 개편하고, 별도로 존재하던 상단 인사말을 위젯 내부로 통합하여 사용자 경험을 개선했습니다.

## 🔗 관련 이슈
Closes #244

## 🛠️ 변경 사항
- `MarketWeatherWidget` 컴포넌트 추가 및 7단계 기상 상태별 아이콘, 색상 매핑
- 홈 화면 상단 `ContextHeader` 인사말을 기상도 위젯 내부로 병합하여 레이아웃 최적화
- 기상 점수(Score) 영역에 `Tooltip`을 적용하여 점수 산출 기준 안내 제공
- TOP SECTORS 및 WATCH OUT 섹션에 영문 코드가 아닌 한글 섹터명 우선 렌더링 적용

## ✅ 셀프 체크리스트 (Self-Check)
- [x] 빌드 성공 여부 확인 (`npm run build` / `yarn build`)
- [x] 린트 체크 통과 여부 확인
- [x] 브라우저에서 직접 기능 동작 확인 및 툴팁 호버 테스트
- [x] 기존 기능에 영향이 없는지 확인
